### PR TITLE
removed image channel ordering conversion

### DIFF
--- a/vsdkx/core/detector.py
+++ b/vsdkx/core/detector.py
@@ -54,9 +54,6 @@ class EventDetector:
             model_settings = {}
         model_profile = get_env_dict(system_config,
                                      "model.profile")
-        self.image_type = get_env_dict(system_config,
-                                       "image_type",
-                                       default='BGR')
         self._debug = get_env_dict(system_config,
                                    "model.debug",
                                    False)
@@ -127,9 +124,6 @@ class EventDetector:
         Returns:
             (dict): the dictionary which hase inference result in
         """
-        if self.image_type == 'BGR':
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-
         addon_stamp = time.time()
         addon_object = AddonObject(frame=frame, inference=None,
                                    shared=metadata)


### PR DESCRIPTION
Removed image channel ordering conversion from BGR to RGB, because that step is already presented in vsdkx-model-yolo-torch. Concretely, I mean [this step](https://github.com/natix-io/vsdkx-model-yolo-torch/blob/cde2155186bb1be745e85567bef0a2867b03aba9/vsdkx/model/yolo_torch/driver.py#L111)